### PR TITLE
기본 프로필 로직 수정 및 회원 탈퇴 로직 보강

### DIFF
--- a/app/src/main/java/com/bestapp/rice/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/bestapp/rice/ui/profile/ProfileFragment.kt
@@ -346,9 +346,7 @@ class ProfileFragment : Fragment() {
             getString(R.string.profile_distinguish_format_8).format(profileUiState.userDocumentID)
 
         // 프로필 이미지
-        binding.ivProfileImage.load(profileUiState.profileImage) {
-            placeholder(R.drawable.sample_profile_image)
-        }
+        binding.ivProfileImage.loadOrDefault(profileUiState.profileImage)
 
         // 모임 횟수
         val badge = MeetingBadge.from(profileUiState.meetingCount)

--- a/app/src/main/java/com/bestapp/rice/ui/profileedit/ProfileEditFragment.kt
+++ b/app/src/main/java/com/bestapp/rice/ui/profileedit/ProfileEditFragment.kt
@@ -8,6 +8,7 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.core.content.ContextCompat.getSystemService
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
@@ -181,6 +182,8 @@ class ProfileEditFragment : Fragment() {
 
     private fun setUI(state: ProfileEditUiState) {
         binding.ivProfile.loadOrDefault(state.profileImage)
+        binding.ivRemoveProfileImage.isGone = state.profileImage.isBlank()
+
         if (state.isNicknameAppliedToView) {
             binding.edtNickname.setText(state.nickname)
         }

--- a/data/src/main/java/com/bestapp/rice/data/repository/MeetingRepository.kt
+++ b/data/src/main/java/com/bestapp/rice/data/repository/MeetingRepository.kt
@@ -28,4 +28,13 @@ interface MeetingRepository {
 
     // pendingmembers 리스트에서 해당 멤버를 제거하기
     suspend fun rejectMember(meetingDocumentID: String, userDocumentID: String): Boolean
+
+    // 탈퇴한 회원이 호스트인 경우 등을 위해 미팅 삭제
+    suspend fun deleteMeeting(meetingDocumentID: String): Boolean
+
+    // 탈퇴한 회원이 호스트가 아닌 경우 등을 위해 미팅에서 참여 정보 삭제
+    suspend fun deleteMeetingMember(meetingDocumentID: String, userDocumentID: String): Boolean
+
+    // 참여 대기중인 모임 반환
+    suspend fun getPendingMeetingByUserDocumentID(userDocumentID: String): List<Meeting>
 }

--- a/data/src/main/java/com/bestapp/rice/data/repository/MeetingRepositoryImpl.kt
+++ b/data/src/main/java/com/bestapp/rice/data/repository/MeetingRepositoryImpl.kt
@@ -166,12 +166,6 @@ internal class MeetingRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteMeetingMember(meetingDocumentID: String, userDocumentID: String): Boolean {
-//        val document = firestoreDB.getMeetingDB().document(meetingDocumentID)
-//        document.update("pendingMembers", FieldValue.arrayRemove(userDocumentID))
-//            .doneSuccessful()
-////        return document.update("members", FieldValue.arrayRemove(userDocumentID))
-////            .doneSuccessful()
-
         val meetingRef = firestoreDB.getMeetingDB().document(meetingDocumentID)
         return firebaseFirestore.runTransaction { transition ->
             transition.update(meetingRef, "pendingMembers", FieldValue.arrayRemove(userDocumentID))

--- a/data/src/main/java/com/bestapp/rice/data/repository/MeetingRepositoryImpl.kt
+++ b/data/src/main/java/com/bestapp/rice/data/repository/MeetingRepositoryImpl.kt
@@ -15,7 +15,8 @@ import javax.inject.Inject
 //Hilt 에러 조심(firebaseFirestore 의존성)
 internal class MeetingRepositoryImpl @Inject constructor(
     private val firebaseFirestore: FirebaseFirestore,
-    private val firestoreDB : FirestoreDB
+    private val firestoreDB : FirestoreDB,
+    private val storageRepository: StorageRepository,
 ) : MeetingRepository {
     private suspend fun Query.toMeetings(): List<Meeting> {
         val querySnapshot = this.get().await()
@@ -37,9 +38,6 @@ internal class MeetingRepositoryImpl @Inject constructor(
         }
 
         return throw Exception("${meetingDocumentID}와 일치하는 미팅정보가 없습니다.")
-
-
-
     }
 
     override suspend fun getMeetings(): List<Meeting> {
@@ -157,6 +155,36 @@ internal class MeetingRepositoryImpl @Inject constructor(
         return firestoreDB.getMeetingDB().document(meetingDocumentID)
             .update("pendingMembers", FieldValue.arrayRemove(userDocumentID))
             .doneSuccessful()
+    }
+
+    override suspend fun deleteMeeting(meetingDocumentID: String): Boolean {
+        val meeting = getMeeting(meetingDocumentID)
+
+        storageRepository.deleteImage(meeting.titleImage)
+        return firestoreDB.getMeetingDB().document(meetingDocumentID).delete()
+            .doneSuccessful()
+    }
+
+    override suspend fun deleteMeetingMember(meetingDocumentID: String, userDocumentID: String): Boolean {
+//        val document = firestoreDB.getMeetingDB().document(meetingDocumentID)
+//        document.update("pendingMembers", FieldValue.arrayRemove(userDocumentID))
+//            .doneSuccessful()
+////        return document.update("members", FieldValue.arrayRemove(userDocumentID))
+////            .doneSuccessful()
+
+        val meetingRef = firestoreDB.getMeetingDB().document(meetingDocumentID)
+        return firebaseFirestore.runTransaction { transition ->
+            transition.update(meetingRef, "pendingMembers", FieldValue.arrayRemove(userDocumentID))
+            transition.update(meetingRef, "members", FieldValue.arrayUnion(userDocumentID))
+        }.doneSuccessful()
+    }
+
+    override suspend fun getPendingMeetingByUserDocumentID(userDocumentID: String): List<Meeting> {
+        return firestoreDB.getMeetingDB()
+            .where(Filter.or(
+                Filter.arrayContains("pendingMembers", userDocumentID),
+            ))
+            .toMeetings()
     }
 
 }

--- a/data/src/main/java/com/bestapp/rice/data/repository/UserRepository.kt
+++ b/data/src/main/java/com/bestapp/rice/data/repository/UserRepository.kt
@@ -9,8 +9,8 @@ interface UserRepository {
     suspend fun getUser(userDocumentID: String): User
     suspend fun login(id: String, pw: String): Boolean
     suspend fun signUpUser(user: User): String
-    suspend fun signOutUser(userDocumentId: String): Boolean
-    suspend fun updateUserNickname(userDocumentId: String, nickname: String): Boolean
+    suspend fun signOutUser(userDocumentID: String): Boolean
+    suspend fun updateUserNickname(userDocumentID: String, nickname: String): Boolean
     suspend fun updateUserTemperature(reviews: List<Review>): Boolean
     suspend fun updateUserMeetingCount(userDocumentID: String): Boolean
     suspend fun updateUserProfileImage(userDocumentID: String, profileImageUri: String?): Boolean

--- a/data/src/main/java/com/bestapp/rice/data/repository/UserRepository.kt
+++ b/data/src/main/java/com/bestapp/rice/data/repository/UserRepository.kt
@@ -16,4 +16,5 @@ interface UserRepository {
     suspend fun updateUserProfileImage(userDocumentID: String, profileImageUri: String?): Boolean
     suspend fun convertImages(userDocumentID: String, images: List<Bitmap>): List<String>
     suspend fun addPost(userDocumentID: String, images: List<String>): Boolean
+    suspend fun deleteUserProfileImage(userDocumentID: String)
 }

--- a/data/src/main/java/com/bestapp/rice/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/bestapp/rice/data/repository/UserRepositoryImpl.kt
@@ -27,7 +27,7 @@ internal class UserRepositoryImpl @Inject constructor(
             return document.toObject<User>()
         }
 
-        return FAKE_USER
+        return User()
     }
 
     override suspend fun login(id: String, pw: String): Boolean {
@@ -97,7 +97,7 @@ internal class UserRepositoryImpl @Inject constructor(
         profileImageUri: String?
     ): Boolean {
         val uri = if (profileImageUri.isNullOrBlank()) {
-            USER_DEFAULT_IMAGE_URI
+            ""
         } else {
             storageRepository.uploadImage(
                 Uri.parse(profileImageUri)
@@ -154,13 +154,5 @@ internal class UserRepositoryImpl @Inject constructor(
         return firestoreDB.getUsersDB().document(userDocumentID)
             .update("posts", FieldValue.arrayUnion(postDocumentId))
             .doneSuccessful()
-    }
-
-    companion object {
-//        private val storageRepositoryImpl = StorageRepositoryImpl()
-
-        private val FAKE_USER = User()
-        private val USER_DEFAULT_IMAGE_URI =
-            "https://firebasestorage.googleapis.com/v0/b/food-879fc.appspot.com/o/images%2F1717515927323.jpg?alt=media&token=026118a6-50ff-4add-a371-5d7f7feda46c"
     }
 }


### PR DESCRIPTION
## (필수) 기능 구현 목록

- 사용자가 기본 프로필로 업데이트하는 경우, 빈 프로필 이미지가 아닌 빈 값으로 DB에 올라가도록 수정
- 프로필 편집 화면에서 기본 프로필 삭제 버튼 Gone처리
- 회원 탈퇴 시 작성한 포스트에 있는 사진, 포스트, 프로필 이미지, 작성한 모임에 있는 사진, 작성한 모임을 삭제하고 참여중인 모임, 참여 신청한 모임 대기열에서 삭제 처리

## 스크린샷

로직 부분이라 생략