### PR TITLE
사용하지 않는 권한 제거 및 미구현 페이지 이동 방지

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,12 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+    <!--    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />-->
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/bestapp/zipbab/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/bestapp/zipbab/ui/home/HomeFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -13,6 +14,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.bestapp.zipbab.R
 import com.bestapp.zipbab.databinding.FragmentHomeBinding
 import com.bestapp.zipbab.model.FilterUiState
 import com.bestapp.zipbab.model.MeetingUiState
@@ -82,8 +84,9 @@ class HomeFragment : Fragment() {
         }
 
         binding.ivNotification.setOnClickListener {
-            val action = HomeFragmentDirections.actionHomeFragmentToNotificationFragment()
-            findNavController().navigate(action)
+            Toast.makeText(requireContext(), getString(R.string.not_yet_implemented), Toast.LENGTH_SHORT).show()
+//            val action = HomeFragmentDirections.actionHomeFragmentToNotificationFragment()
+//            findNavController().navigate(action)
         }
 
         binding.fb.setOnClickListener {

--- a/app/src/main/java/com/bestapp/zipbab/ui/meetingmanagement/MeetingManagementFragment.kt
+++ b/app/src/main/java/com/bestapp/zipbab/ui/meetingmanagement/MeetingManagementFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.view.isInvisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -137,7 +138,8 @@ class MeetingManagementFragment : Fragment() {
             viewModel.bottomBtnEvent(MoveNavigation.END_MEETING)
         }
         binding.btnMyGroupLocation.setOnClickListener {
-            viewModel.bottomBtnEvent(MoveNavigation.GO_GROUP_LOCATION)
+            Toast.makeText(requireContext(), getString(R.string.not_yet_implemented), Toast.LENGTH_SHORT).show()
+            // viewModel.bottomBtnEvent(MoveNavigation.GO_GROUP_LOCATION)
         }
         binding.clHost.setOnClickListener {
             val action =

--- a/app/src/main/java/com/bestapp/zipbab/ui/mettinglist/MeetingListFragment.kt
+++ b/app/src/main/java/com/bestapp/zipbab/ui/mettinglist/MeetingListFragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -129,7 +130,8 @@ class MeetingListFragment : Fragment() {
 
                     clickAreas.forEach { view ->
                         view.setOnClickListener {
-                            goReview(meetingListUis[i])
+                            Toast.makeText(requireContext(), getString(R.string.not_yet_implemented), Toast.LENGTH_SHORT).show()
+                            // goReview(meetingListUis[i])
                         }
                     }
                 }

--- a/app/src/main/java/com/bestapp/zipbab/ui/signup/SignUpFragment.kt
+++ b/app/src/main/java/com/bestapp/zipbab/ui/signup/SignUpFragment.kt
@@ -1,9 +1,13 @@
 package com.bestapp.zipbab.ui.signup
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.text.Editable
 import android.text.SpannableString
 import android.text.TextWatcher
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
 import android.text.util.Linkify
 import android.view.LayoutInflater
@@ -58,8 +62,6 @@ class SignUpFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.tvTerms.visibility = View.VISIBLE
-        binding.bCheck.visibility = View.VISIBLE
         initViews()
         setListener()
         setObserve()
@@ -69,6 +71,10 @@ class SignUpFragment : Fragment() {
         signUpViewModel.getPrivacyUrl()
 
         val spannableString = SpannableString(binding.tvTerms.text)
+
+        binding.tvTerms.setOnClickListener {
+            binding.bCheck.isChecked = !binding.bCheck.isChecked
+        }
 
         spannableString.setSpan(
             ForegroundColorSpan(resources.getColor(R.color.main_color, requireActivity().theme)),
@@ -80,17 +86,16 @@ class SignUpFragment : Fragment() {
         binding.tvTerms.text = spannableString
 
         val mTransform = Linkify.TransformFilter { _, url -> "" }
-        val pattern = Pattern.compile("이용약관")
+        val patternUrl = Pattern.compile("이용약관")
 
         viewLifecycleOwner.lifecycleScope.launch {
             signUpViewModel.requestPrivacyUrl.collectLatest { privacy ->
                 if (privacy.link.isNotEmpty()) {
-                    Linkify.addLinks(binding.tvTerms, pattern, privacy.link, null, mTransform)
+                    Linkify.addLinks(binding.tvTerms, patternUrl, privacy.link, null, mTransform)
                 }
             }
         }
     }
-
 
     private fun setObserve() {
         signUpViewModel.isSignUpState.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/bestapp/zipbab/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/bestapp/zipbab/ui/signup/SignUpViewModel.kt
@@ -6,10 +6,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bestapp.zipbab.data.model.remote.PlaceLocation
+import com.bestapp.zipbab.data.model.remote.Privacy
 import com.bestapp.zipbab.data.model.remote.User
 import com.bestapp.zipbab.data.repository.AppSettingRepository
 import com.bestapp.zipbab.data.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -84,6 +88,15 @@ class SignUpViewModel @Inject constructor(
             return SignUpValidState.UntilPassWord
         }
         return SignUpValidState.All
+    }
+
+    private val _requestPrivacyUrl = MutableStateFlow(Privacy())
+    val requestPrivacyUrl: StateFlow<Privacy> = _requestPrivacyUrl.asStateFlow()
+
+    fun getPrivacyUrl() {
+        viewModelScope.launch {
+            _requestPrivacyUrl.emit(appSettingRepository.getPrivacyInfo())
+        }
     }
 
     fun userDataSave() {

--- a/app/src/main/res/layout/fragment_sign_up.xml
+++ b/app/src/main/res/layout/fragment_sign_up.xml
@@ -234,7 +234,7 @@
             android:id="@+id/etv_password_compare"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="21dp"
+            android:layout_marginHorizontal="26dp"
             android:layout_marginTop="@dimen/default_margin8"
             android:background="@drawable/background_edittext"
             android:backgroundTint="@color/light_gray"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,5 +166,5 @@
 
     <string name="home_my_meeting_empty_text">현재 참여 중인 모임이 없어요.</string>
     <string name="login_fail">이메일이나 비밀번호가 일치하지않습니다.</string>
-    <string name="not_yet_implemented">아직 미구현 기능입니다.</string>
+    <string name="not_yet_implemented">이 기능은 업데이트 예정입니다.</string>
 </resources>

--- a/data/src/main/java/com/bestapp/zipbab/data/repository/MeetingRepositoryImpl.kt
+++ b/data/src/main/java/com/bestapp/zipbab/data/repository/MeetingRepositoryImpl.kt
@@ -37,7 +37,7 @@ internal class MeetingRepositoryImpl @Inject constructor(
             return document.toObject<Meeting>()
         }
 
-        return throw Exception("${meetingDocumentID}와 일치하는 미팅정보가 없습니다.")
+        return Meeting()
     }
 
     override suspend fun getMeetings(): List<Meeting> {


### PR DESCRIPTION
## (필수) 기능 구현 목록

- Androidmanifest.xml 에서 사용하지 않는 android.permission.POST_NOTIFICATIONS 권한 제거 (필수 reject 사유)
- 미구현 페이지 이동 방지 및 "이 기능은 업데이트 예정입니다." Toast show (충분한 reject 사유)

## 참고사항

- fireBase 및 KakaoMap의 패키지 경로도 수정완료했습니다.
  -> 주소 검색 및 지도 Map, Firebase 통신 등 정상 작동 확인했습니다.

## (필수) 스크린샷
<p align="center">
   <img src="https://github.com/MeetUpEat/Zipbab/assets/52482206/4fd7c46b-4497-486f-a0d0-ee7ad1131871" height=700px align="left">
</p>