### PR TITLE
fix: Map 메모리 누수 제거, 배터리 효율을 고려하여 정확도 감축

### DIFF
--- a/app/src/main/java/com/bestapp/zipbab/ui/meetupmap/MeetUpMapFragment.kt
+++ b/app/src/main/java/com/bestapp/zipbab/ui/meetupmap/MeetUpMapFragment.kt
@@ -239,9 +239,10 @@ class MeetUpMapFragment : Fragment() {
     override fun onDestroyView() {
         viewModel.removeUserLabel()
         binding.layout.rv.adapter = null
+        binding.mv.finish()
         _binding = null
-        standardBottomSheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
         _map = null
+        standardBottomSheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
 
         super.onDestroyView()
     }

--- a/app/src/main/java/com/bestapp/zipbab/userlocation/LocationServiceImpl.kt
+++ b/app/src/main/java/com/bestapp/zipbab/userlocation/LocationServiceImpl.kt
@@ -30,7 +30,7 @@ class LocationServiceImpl @Inject constructor(
         ) {
             LatLng = suspendCancellableCoroutine { continuation ->
                 locationClient.getCurrentLocation(
-                    Priority.PRIORITY_HIGH_ACCURACY,
+                    Priority.PRIORITY_BALANCED_POWER_ACCURACY,
                     null
                 ).addOnSuccessListener { location ->
                     location?.let {

--- a/app/src/main/res/layout/bottom_sheets_meeting_list.xml
+++ b/app/src/main/res/layout/bottom_sheets_meeting_list.xml
@@ -11,7 +11,6 @@
         android:id="@+id/bs_meetings"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:backgroundTint="@color/white"
         style="@style/BottomSheetDialog"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 


### PR DESCRIPTION
## (필수) 기능 구현 목록

- Fragment 파괴 시, Map 객체 finish()
- [위치 정확도 수정](https://developer.android.com/develop/sensors-and-location/location/battery?hl=ko#accuracy)
    - PRIORITY_HIGH_ACCURACY to PRIORITY_BALANCED_POWER_ACCURACY
    - 변경한 이유 : 사용자의 위치 값을 통한 응급 구조 서비스와 같이 필수적으로 정확한 위치를 필요로 하지 않기 때문에

## 참고사항

- 전체적으로 모든 기능 테스트 시, Leaks가 발생하지 않는 것을 확인했습니다.