### PR TITLE
다크모드 대응한 Background 색상 지정

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Base application theme. -->
     <style name="Base.Theme.Zipbab" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowBackground">@color/black</item>
         <!-- Customize your dark theme here. -->
         <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
     </style>


### PR DESCRIPTION
## 기능 구현 목록

- Theme에서 별도의 background 색상을 지정하지 않으면 연한 검은색으로 지정되는 문제를 해결하기 위해 theme에서 `android:windowBackground` 색상을 지정

## 스크린샷

이전
<img src="https://github.com/MeetUpEat/Zipbab/assets/48354989/9db92fdb-ff54-4598-98a9-50f87270e741" width=300 height=700 />

이후
<img src="https://github.com/MeetUpEat/Zipbab/assets/48354989/ae953bbe-945f-4259-8224-2e2cbaf15bf0" width=300 height=700 />